### PR TITLE
fix: ViewBuilderを10個までのViewをサポートするように拡張

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,18 +529,20 @@ swift run KeyTestVerify       # グローバルキーハンドラーの動作確
 swift run ListTest            # Listコンポーネントのテスト（Range error修正済み）
 swift run MinimalListTest     # シンプルなListのテスト
 
-# ⚠️ 既知の問題があるサンプル
-swift run ScrollViewTest      # Range errorが発生する場合があります
-swift run ForEachTest         # ViewBuilder制限により修正が必要
-swift run InteractiveFormTest # ハングする場合があります
+# ✅ 修正完了したサンプル（以前は問題あり）
+swift run ScrollViewTest      # Range error修正済み - 正常に動作します
+swift run ForEachTest         # ViewBuilder制限を10個まで拡張 - コンパイル可能（表示の問題は残存）
+swift run InteractiveFormTest # ESCキー修正により解決済み - 正常に終了できます
 ```
 
 #### 既知の問題と回避策
 
 1. **Float→Int変換エラー**: Yogaレイアウトエンジンから返される値がNaNやinfiniteの場合があります。これは修正済みです。
 
-2. **Range error**: ForEachやListを使用する際に発生する場合があります。現在調査中です。
+2. **Range error**: ForEachやListを使用する際に発生する場合があります。ScrollViewTestのRange errorは修正済みです。
 
-3. **ViewBuilder制限**: 1つのブロック内に5つ以上のViewを配置できません。VStackやGroupでグループ化してください。
+3. **ViewBuilder制限**: ~~1つのブロック内に5つ以上のViewを配置できません。~~ **修正済み**: 最大10個のViewまで配置できるように拡張しました。
+
+4. **ForEachTest表示問題**: HStackのボーダー描画とBackgroundLayoutViewのANSIエスケープ処理に問題があり、表示が崩れる場合があります。
 
 

--- a/Sources/SwiftTUI/Views/ViewBuilder.swift
+++ b/Sources/SwiftTUI/Views/ViewBuilder.swift
@@ -26,6 +26,31 @@ public struct ViewBuilder {
         TupleView((c0, c1, c2, c3, c4))
     }
     
+    // 6つのView
+    public static func buildBlock<C0: View, C1: View, C2: View, C3: View, C4: View, C5: View>(_ c0: C0, _ c1: C1, _ c2: C2, _ c3: C3, _ c4: C4, _ c5: C5) -> TupleView<(C0, C1, C2, C3, C4, C5)> {
+        TupleView((c0, c1, c2, c3, c4, c5))
+    }
+    
+    // 7つのView
+    public static func buildBlock<C0: View, C1: View, C2: View, C3: View, C4: View, C5: View, C6: View>(_ c0: C0, _ c1: C1, _ c2: C2, _ c3: C3, _ c4: C4, _ c5: C5, _ c6: C6) -> TupleView<(C0, C1, C2, C3, C4, C5, C6)> {
+        TupleView((c0, c1, c2, c3, c4, c5, c6))
+    }
+    
+    // 8つのView
+    public static func buildBlock<C0: View, C1: View, C2: View, C3: View, C4: View, C5: View, C6: View, C7: View>(_ c0: C0, _ c1: C1, _ c2: C2, _ c3: C3, _ c4: C4, _ c5: C5, _ c6: C6, _ c7: C7) -> TupleView<(C0, C1, C2, C3, C4, C5, C6, C7)> {
+        TupleView((c0, c1, c2, c3, c4, c5, c6, c7))
+    }
+    
+    // 9つのView
+    public static func buildBlock<C0: View, C1: View, C2: View, C3: View, C4: View, C5: View, C6: View, C7: View, C8: View>(_ c0: C0, _ c1: C1, _ c2: C2, _ c3: C3, _ c4: C4, _ c5: C5, _ c6: C6, _ c7: C7, _ c8: C8) -> TupleView<(C0, C1, C2, C3, C4, C5, C6, C7, C8)> {
+        TupleView((c0, c1, c2, c3, c4, c5, c6, c7, c8))
+    }
+    
+    // 10つのView
+    public static func buildBlock<C0: View, C1: View, C2: View, C3: View, C4: View, C5: View, C6: View, C7: View, C8: View, C9: View>(_ c0: C0, _ c1: C1, _ c2: C2, _ c3: C3, _ c4: C4, _ c5: C5, _ c6: C6, _ c7: C7, _ c8: C8, _ c9: C9) -> TupleView<(C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)> {
+        TupleView((c0, c1, c2, c3, c4, c5, c6, c7, c8, c9))
+    }
+    
     // 条件分岐サポート
     public static func buildEither<TrueContent: View, FalseContent: View>(first: TrueContent) -> ConditionalContent<TrueContent, FalseContent> {
         .first(first)


### PR DESCRIPTION
## 概要

ForEachTestでViewBuilderの制限（最大5個まで）によるコンパイルエラーが発生していた問題を修正しました。

## 変更内容

### ViewBuilderの拡張
- 6〜10個のViewを受け取る`buildBlock`メソッドを追加
- これにより、ViewBuilder内で最大10個までのViewを配置できるようになりました

## 解決した問題

以下の既知の問題をすべて確認・解決しました：

1. **ScrollViewTest Range error**: ✅ 解決済み（エラーなし）
2. **InteractiveFormTest hang**: ✅ 解決済み（ESCキー修正により解決）  
3. **ForEachTest ViewBuilder limitation**: ✅ 今回の修正で解決

## 動作確認

```bash
# ForEachTestのコンパイルと実行
swift run ForEachTest

# ScrollViewTestの動作確認
swift run ScrollViewTest

# InteractiveFormTestの動作確認
swift run InteractiveFormTest
```

すべてのテストが正常にコンパイル・実行されることを確認しました。

## 今後の課題

ForEachTest実行時の表示問題（HStackのボーダー描画とBackgroundLayoutViewのANSIエスケープ処理）は別途修正が必要です。

🤖 Generated with [Claude Code](https://claude.ai/code)