### PR TITLE
feat: ScrollViewコンポーネントのユニットテスト実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,7 +355,7 @@ SwiftTUI.run(App())
 
 ## ユニットテスト TODO
 
-### 実装済みテスト（134テスト）
+### 実装済みテスト（151テスト）
 - [x] **TextTests** (7テスト) - 基本的なText表示、特殊文字、改行、文字列補間
 - [x] **TextModifierTests** (6テスト) - padding、border、bold、foregroundColor、background、連鎖
 - [x] **CompositeViewTests** (4テスト) - VStack、HStack、ネストされたスタック、スペーシング
@@ -368,6 +368,7 @@ SwiftTUI.run(App())
 - [x] **EnvironmentTests** (14テスト) - 環境値伝播、Observable統合、カスタムキー、エッジケース
 - [x] **ForEachTests** (18テスト) - Range/Identifiable/KeyPath ForEach、ネスト、エッジケース
 - [x] **ListTests** (12テスト) - 基本List表示、セパレーター、ForEach組み合わせ、エッジケース
+- [x] **ScrollViewTests** (17テスト) - 基本スクロール、クリッピング、スクロールバー、エッジケース
 
 ### Phase 1 - 基本コンポーネントのテスト
 - [x] **ButtonTests** ✅ - Buttonビューのテスト
@@ -410,16 +411,19 @@ SwiftTUI.run(App())
   - KeyPath（id: \.self）での動作
   - 空の配列での動作
 
-- [ ] **ListTests** - Listビューのテスト
+- [x] **ListTests** ✅ - Listビューのテスト
   - 項目の表示と自動区切り線
   - 空のリスト
   - 単一項目のリスト
   - ForEachとの組み合わせ
 
-- [ ] **ScrollViewTests** - ScrollViewのテスト
-  - コンテンツのクリッピング
-  - スクロールバーの表示
-  - frame制約との組み合わせ
+- [x] **ScrollViewTests** ✅ - ScrollViewのテスト
+  - 基本スクロール機能（垂直・水平・両方向）
+  - 固定ビューポート（3行×5文字）でのクリッピング
+  - スクロールバー表示設定（showsIndicators）
+  - 大きなコンテンツでの動作
+  - ネストされたViewとVStack内配置
+  - 既知の制限：.frame()モディファイア無視、グローバル状態共有
 
 ### Phase 5 - インタラクティブコンポーネントのテスト
 - [ ] **ToggleTests** - Toggleビューのテスト

--- a/README.md
+++ b/README.md
@@ -1087,6 +1087,7 @@ swift test --filter SwiftTUITests.BindingTests
 swift test --filter SwiftTUITests.EnvironmentTests
 swift test --filter SwiftTUITests.ForEachTests
 swift test --filter SwiftTUITests.ListTests
+swift test --filter SwiftTUITests.ScrollViewTests
 
 # 特定のテストメソッドを実行
 swift test --filter SwiftTUITests.TextTests.testTextBasic
@@ -1097,6 +1098,8 @@ swift test --filter SwiftTUITests.ForEachTests.testForEachRangeBasic
 swift test --filter SwiftTUITests.ForEachTests.testForEachIdentifiableBasic
 swift test --filter SwiftTUITests.ListTests.testListBasicDisplay
 swift test --filter SwiftTUITests.ListTests.testListWithForEachRange
+swift test --filter SwiftTUITests.ScrollViewTests.testScrollViewBasicVertical
+swift test --filter SwiftTUITests.ScrollViewTests.testScrollViewContentClipping
 ```
 
 #### テストの内容
@@ -1181,6 +1184,15 @@ swift test --filter SwiftTUITests.ListTests.testListWithForEachRange
   - ネストされたView（VStack内のList、List内のVStack）
   - エッジケース（長いコンテンツ、VStack内での配置）
   - 注意：List実装には既知の制限（中間項目の消失）があり、テストで考慮済み
+
+- **ScrollViewTests**: ScrollViewスクロール可能コンテナの動作をテスト
+  - 基本スクロール機能（垂直、水平、両方向、スクロール不要、空コンテンツ）
+  - フレーム制約とクリッピング（固定ビューポート3行×5文字、長いテキストの切り詰め）
+  - スクロールバー表示（showsIndicators設定、大きなコンテンツでの動作）
+  - ANSIエスケープシーケンス処理（色付きテキストの保持）
+  - エッジケース（単一行、ネストされたView、VStack内配置、複数インスタンス）
+  - 注意：現在の実装は固定ビューポートサイズで、.frame()モディファイアは無視される
+  - グローバル状態管理により複数ScrollView間で状態が共有される制限あり
 
 - **FrameModifierTests**: .frame()モディファイアの動作をテスト
   - 幅制約のみのテスト（短いテキスト、長いテキスト、パディング）

--- a/Tests/SwiftTUITests/ScrollViewTests.swift
+++ b/Tests/SwiftTUITests/ScrollViewTests.swift
@@ -1,0 +1,422 @@
+//
+//  ScrollViewTests.swift
+//  SwiftTUITests
+//
+//  Tests for ScrollView component with scrolling and viewport functionality
+//
+//  Note: Current ScrollView implementation has fixed viewport size (3 lines height, 5 chars width)
+//  and ignores .frame() modifiers
+//
+
+import XCTest
+@testable import SwiftTUI
+
+final class ScrollViewTests: SwiftTUITestCase {
+    
+    // MARK: - Basic Scroll Functionality Tests
+    
+    func testScrollViewBasicVertical() {
+        // Given - Vertical ScrollView with fixed 3-line viewport
+        struct TestView: View {
+            var body: some View {
+                ScrollView {
+                    VStack {
+                        Text("L1")  // Short text to fit within 5 char width
+                        Text("L2")
+                        Text("L3")
+                        Text("L4")
+                        Text("L5")
+                    }
+                }
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 20, height: 10)
+        
+        // Then - Should show first 3 lines due to fixed viewport
+        XCTAssertTrue(output.contains("L1"), "Should show first line")
+        XCTAssertTrue(output.contains("L2"), "Should show second line")
+        XCTAssertTrue(output.contains("L3"), "Should show third line")
+        XCTAssertFalse(output.contains("L4"), "Should not show fourth line (clipped)")
+        XCTAssertFalse(output.contains("L5"), "Should not show fifth line (clipped)")
+    }
+    
+    func testScrollViewBasicHorizontal() {
+        // Given - Horizontal ScrollView with fixed 5-char viewport
+        struct TestView: View {
+            var body: some View {
+                ScrollView(.horizontal) {
+                    HStack(spacing: 0) {
+                        Text("ABCDE")  // Exactly 5 chars
+                        Text("FG")     // Will be clipped
+                    }
+                }
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 20, height: 10)
+        
+        // Then - Should show only first 5 characters
+        XCTAssertTrue(output.contains("ABCDE"), "Should show first 5 chars")
+        XCTAssertFalse(output.contains("FG"), "Should not show chars beyond viewport")
+    }
+    
+    func testScrollViewBothAxes() {
+        // Given - ScrollView with both axes enabled
+        struct TestView: View {
+            var body: some View {
+                ScrollView([.horizontal, .vertical]) {
+                    VStack {
+                        Text("12345")  // Will fit exactly in 5-char width
+                        Text("67890")
+                        Text("ABCDE")
+                        Text("FGHIJ")  // Beyond 3-line viewport
+                    }
+                }
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 30, height: 10)
+        
+        // Then - Should clip to 3x5 viewport
+        XCTAssertTrue(output.contains("12345"), "Should show first line")
+        XCTAssertTrue(output.contains("67890"), "Should show second line")
+        XCTAssertTrue(output.contains("ABCDE"), "Should show third line")
+        XCTAssertFalse(output.contains("FGHIJ"), "Should not show fourth line")
+    }
+    
+    func testScrollViewNoScroll() {
+        // Given - Content smaller than viewport
+        struct TestView: View {
+            var body: some View {
+                ScrollView {
+                    Text("Hi")  // 2 chars, 1 line
+                }
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 20, height: 10)
+        
+        // Then
+        XCTAssertTrue(output.contains("Hi"), "Should show all content")
+    }
+    
+    func testScrollViewEmptyContent() {
+        // Given
+        struct TestView: View {
+            var body: some View {
+                ScrollView {
+                    EmptyView()
+                }
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 20, height: 10)
+        
+        // Then
+        XCTAssertNotNil(output, "Should render empty ScrollView")
+    }
+    
+    // MARK: - Frame Constraints and Clipping Tests
+    
+    func testScrollViewIgnoresFrameModifier() {
+        // Given - .frame() modifier is ignored by ScrollView
+        struct TestView: View {
+            var body: some View {
+                ScrollView {
+                    VStack {
+                        Text("A")
+                        Text("B")
+                        Text("C")
+                        Text("D")
+                    }
+                }
+                .frame(height: 10)  // This is ignored
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 20, height: 20)
+        
+        // Then - Still shows only 3 lines
+        XCTAssertTrue(output.contains("A"), "Should show A")
+        XCTAssertTrue(output.contains("B"), "Should show B")
+        XCTAssertTrue(output.contains("C"), "Should show C")
+        XCTAssertFalse(output.contains("D"), "Should not show D")
+    }
+    
+    func testScrollViewContentClipping() {
+        // Given - Long text that exceeds 5-char width
+        struct TestView: View {
+            var body: some View {
+                ScrollView {
+                    VStack {
+                        Text("Hello")  // "Hello" = 5 chars, fits exactly
+                        Text("World!")  // "World!" = 6 chars, last char clipped
+                        Text("12345678")  // Only first 5 chars shown
+                    }
+                }
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 30, height: 10)
+        
+        // Then
+        XCTAssertTrue(output.contains("Hello"), "Should show Hello completely")
+        XCTAssertTrue(output.contains("World"), "Should show World")
+        XCTAssertFalse(output.contains("!"), "Should not show exclamation mark")
+        XCTAssertTrue(output.contains("12345"), "Should show first 5 digits")
+        XCTAssertFalse(output.contains("678"), "Should not show last 3 digits")
+    }
+    
+    func testScrollViewHorizontalClipping() {
+        // Given
+        struct TestView: View {
+            var body: some View {
+                ScrollView(.horizontal) {
+                    Text("1234567890")  // 10 chars, only 5 shown
+                }
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 20, height: 10)
+        
+        // Then
+        XCTAssertTrue(output.contains("12345"), "Should show first 5 chars")
+        XCTAssertFalse(output.contains("67890"), "Should not show last 5 chars")
+    }
+    
+    func testScrollViewANSIHandling() {
+        // Given - Content with color modifiers
+        struct TestView: View {
+            var body: some View {
+                ScrollView {
+                    VStack {
+                        Text("R").foregroundColor(.red)
+                        Text("G").foregroundColor(.green)
+                        Text("B").foregroundColor(.blue)
+                    }
+                }
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 20, height: 10)
+        
+        // Then - TestRenderer strips ANSI, but text remains
+        XCTAssertTrue(output.contains("R"), "Should show R")
+        XCTAssertTrue(output.contains("G"), "Should show G")
+        XCTAssertTrue(output.contains("B"), "Should show B")
+    }
+    
+    // MARK: - Scrollbar Display Tests
+    
+    func testScrollViewIndicatorsShown() {
+        // Given - Default showsIndicators = true
+        struct TestView: View {
+            var body: some View {
+                ScrollView {
+                    VStack {
+                        ForEachRange(0..<10) { i in
+                            Text("\(i)")
+                        }
+                    }
+                }
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 20, height: 10)
+        
+        // Then - Content is shown (scrollbar rendering is internal)
+        XCTAssertTrue(output.contains("0"), "Should show 0")
+        XCTAssertTrue(output.contains("1"), "Should show 1")
+        XCTAssertTrue(output.contains("2"), "Should show 2")
+        XCTAssertFalse(output.contains("3"), "Should not show 3")
+    }
+    
+    func testScrollViewIndicatorsHidden() {
+        // Given
+        struct TestView: View {
+            var body: some View {
+                ScrollView(showsIndicators: false) {
+                    VStack {
+                        Text("A")
+                        Text("B")
+                        Text("C")
+                        Text("D")
+                    }
+                }
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 20, height: 10)
+        
+        // Then
+        XCTAssertTrue(output.contains("A"), "Should show A")
+        XCTAssertTrue(output.contains("B"), "Should show B")
+        XCTAssertTrue(output.contains("C"), "Should show C")
+        XCTAssertFalse(output.contains("D"), "Should not show D")
+    }
+    
+    func testScrollViewWithLargeContent() {
+        // Given - Content much larger than viewport
+        struct TestView: View {
+            var body: some View {
+                ScrollView {
+                    VStack {
+                        ForEachRange(0..<50) { i in
+                            Text("L\(i)")
+                        }
+                    }
+                }
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 20, height: 10)
+        
+        // Then - Shows only first 3 items
+        XCTAssertTrue(output.contains("L0"), "Should show L0")
+        XCTAssertTrue(output.contains("L1"), "Should show L1")
+        XCTAssertTrue(output.contains("L2"), "Should show L2")
+        XCTAssertFalse(output.contains("L3"), "Should not show L3")
+        XCTAssertFalse(output.contains("L49"), "Should not show L49")
+    }
+    
+    // MARK: - Edge Cases Tests
+    
+    func testScrollViewSingleLine() {
+        // Given
+        struct TestView: View {
+            var body: some View {
+                ScrollView {
+                    Text("One")
+                }
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 20, height: 10)
+        
+        // Then
+        XCTAssertTrue(output.contains("One"), "Should show single line")
+    }
+    
+    func testScrollViewNestedViews() {
+        // Given - Complex nested structure
+        struct TestView: View {
+            var body: some View {
+                ScrollView {
+                    VStack {
+                        Text("Top")
+                        HStack(spacing: 0) {
+                            Text("L")
+                            Text("R")
+                        }
+                        Text("Bot")
+                        Text("Hidden")  // 4th line, should be clipped
+                    }
+                }
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 30, height: 15)
+        
+        // Then
+        XCTAssertTrue(output.contains("Top"), "Should show top")
+        XCTAssertTrue(output.contains("L"), "Should show L")
+        XCTAssertTrue(output.contains("R"), "Should show R")
+        XCTAssertTrue(output.contains("Bot"), "Should show bottom")
+        XCTAssertFalse(output.contains("Hidden"), "Should not show hidden")
+    }
+    
+    func testScrollViewInVStack() {
+        // Given - ScrollView inside VStack
+        struct TestView: View {
+            var body: some View {
+                VStack {
+                    Text("Title")
+                    
+                    ScrollView {
+                        VStack {
+                            Text("S1")
+                            Text("S2")
+                            Text("S3")
+                            Text("S4")  // Beyond viewport
+                        }
+                    }
+                    
+                    Text("Footer")
+                }
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 20, height: 15)
+        
+        // Then
+        XCTAssertTrue(output.contains("Title"), "Should show title")
+        XCTAssertTrue(output.contains("S1"), "Should show S1")
+        XCTAssertTrue(output.contains("S2"), "Should show S2")
+        XCTAssertTrue(output.contains("S3"), "Should show S3")
+        XCTAssertFalse(output.contains("S4"), "Should not show S4")
+        XCTAssertTrue(output.contains("Footer"), "Should show footer")
+    }
+    
+    func testScrollViewWithSpacing() {
+        // Given - VStack with spacing inside ScrollView
+        struct TestView: View {
+            var body: some View {
+                ScrollView {
+                    VStack(spacing: 1) {
+                        Text("A")
+                        Text("B")
+                        Text("C")  // May be clipped due to spacing
+                    }
+                }
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 20, height: 10)
+        
+        // Then
+        XCTAssertTrue(output.contains("A"), "Should show A")
+        XCTAssertTrue(output.contains("B"), "Should show B")
+        // C might be clipped due to spacing taking up lines
+    }
+    
+    func testScrollViewMultipleInstances() {
+        // Given - Multiple ScrollViews (affected by global state issue)
+        struct TestView: View {
+            var body: some View {
+                HStack {
+                    ScrollView {
+                        Text("SV1")
+                    }
+                    
+                    ScrollView {
+                        Text("SV2")
+                    }
+                }
+            }
+        }
+        
+        // When
+        let output = TestRenderer.render(TestView(), width: 20, height: 10)
+        
+        // Then - Both should render, but may share state
+        XCTAssertTrue(output.contains("SV1"), "Should show SV1")
+        XCTAssertTrue(output.contains("SV2"), "Should show SV2")
+    }
+}


### PR DESCRIPTION
## 概要

ScrollViewコンポーネント用の包括的なユニットテストを実装しました。スクロール可能コンテナの動作確認と、現在の実装制限を明確に文書化しています。

## 実装内容

### 📋 テストケース（17個）

#### 基本スクロール機能テスト（5個）
- `testScrollViewBasicVertical`: 垂直スクロール（デフォルト動作）
- `testScrollViewBasicHorizontal`: 水平スクロール設定
- `testScrollViewBothAxes`: 両方向スクロール（.horizontal, .vertical）
- `testScrollViewNoScroll`: スクロール不要な小さなコンテンツ
- `testScrollViewEmptyContent`: 空コンテンツの処理

#### フレーム制約とクリッピングテスト（4個）
- `testScrollViewIgnoresFrameModifier`: .frame()モディファイアが無視される確認
- `testScrollViewContentClipping`: 長いテキストの適切なクリッピング
- `testScrollViewHorizontalClipping`: 水平方向のクリッピング動作
- `testScrollViewANSIHandling`: 色付きテキストのANSI処理

#### スクロールバー表示テスト（3個）
- `testScrollViewIndicatorsShown`: showsIndicators=true（デフォルト）
- `testScrollViewIndicatorsHidden`: showsIndicators=false設定
- `testScrollViewWithLargeContent`: 大きなコンテンツでの動作確認

#### エッジケーステスト（5個）
- `testScrollViewSingleLine`: 単一行コンテンツ
- `testScrollViewNestedViews`: 複雑なネスト構造（VStack内のHStack）
- `testScrollViewInVStack`: 他のコンポーネントとの組み合わせ
- `testScrollViewWithSpacing`: スペーシング付きVStackの処理
- `testScrollViewMultipleInstances`: 複数ScrollViewインスタンス

### 🔧 技術的対応

#### 現在の実装制限への対応
- **固定ビューポート**: 3行×5文字に固定されているため、テストケースを調整
- **.frame()無視**: モディファイアが効かない問題を明示的にテスト
- **グローバル状態**: 複数インスタンス間での状態共有問題を文書化

#### テスト設計の工夫
- 短いテキスト（"L1", "L2"等）で5文字幅制限に対応
- クリッピングの境界値テスト（"Hello"=5文字、"World\!"=6文字）
- スペーシングによる表示行数への影響を考慮

### 📊 テスト結果

```bash
swift test --filter ScrollViewTests
```

- **実行数**: 17テスト
- **成功数**: 17テスト（100%成功率）
- **実行時間**: 約0.19秒

### 📚 ドキュメント更新

#### README.md
- ユニットテストセクションにScrollViewTests実行方法を追加
- 特定テストクラス・メソッドの実行例を追加
- ScrollViewTestsの内容詳細と既知制限を明記

#### CLAUDE.md
- 実装済みテスト数を134→151テストに更新
- ScrollViewTests（17テスト）を実装済みリストに追加
- Phase 4の動的リストテストを完了状態に更新

## 動作確認方法

### 全ScrollViewTestsの実行
```bash
swift test --filter SwiftTUITests.ScrollViewTests
```

### 特定テストの実行
```bash
# 基本垂直スクロール
swift test --filter SwiftTUITests.ScrollViewTests.testScrollViewBasicVertical

# コンテンツクリッピング
swift test --filter SwiftTUITests.ScrollViewTests.testScrollViewContentClipping

# フレーム無視の確認
swift test --filter SwiftTUITests.ScrollViewTests.testScrollViewIgnoresFrameModifier
```

### ScrollViewコンポーネントの動作確認
```bash
# 実際のScrollView動作を確認
swift run ScrollViewTest
swift run SimpleScrollTest
```

## 実装上の注意事項

### 既知の制限（現在の実装）
1. **固定ビューポート**: 垂直3行、水平5文字に固定
2. **.frame()無視**: モディファイアを設定しても効果なし
3. **グローバル状態**: 複数ScrollView間で状態が共有される
4. **キーボード操作**: 静的テストでは検証不可（初期表示のみ）

### 将来の改善方向
1. Yogaレイアウトとの適切な統合
2. インスタンスごとの状態管理
3. 動的なビューポートサイズ対応
4. .frame()モディファイアのサポート

## PR内容

### 変更されたファイル
- ✅ `Tests/SwiftTUITests/ScrollViewTests.swift` - 新規作成（422行）
- ✅ `README.md` - ScrollViewTests説明追加（+12行）
- ✅ `CLAUDE.md` - テスト完了状況更新（+10行, -6行）

### コミット履歴
1. `test: ScrollViewコンポーネントのユニットテストを実装`
2. `docs: READMEにScrollViewTestsの動作確認方法を追記`
3. `docs: CLAUDE.mdのユニットテスト完了状況を更新`

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>